### PR TITLE
add jsconfig.json

### DIFF
--- a/learn/jsconfig.json
+++ b/learn/jsconfig.json
@@ -1,0 +1,6 @@
+{
+    "compilerOptions": {
+        "baseUrl": "src"
+    },
+    "includes": ["src"]
+}


### PR DESCRIPTION
수정사항

- jsconfig.json 파일을 추가했습니다. 원래는 하나의 파일에서 다른 파일을 참조하기 위해서는 상대경로를 사용해야하는데 이 파일을 추가함으로써 절대경로로 사용할 수 있습니다. 예를 들어, `page/login.js`파일에서 `lib/api/register.js`를 import하려면 `import ... from '../lib/api/register.js'`라고 해야하지만 절대경로로 `import ... from 'lib/api/register.js'` 이렇게 일관성있게 사용할 수 있습니다.